### PR TITLE
Scoring updates

### DIFF
--- a/neurons/score/reddit_score.py
+++ b/neurons/score/reddit_score.py
@@ -157,7 +157,10 @@ def calculateScore(responses = [], tag = 'tao'):
         time_diff_list[i] = time_diff_score
         length_list[i] = len(response)
         correct_list[i] = correct_score
-        correct_search_result_list[i] = correct_search_result / len(response)
+        if len(response) > 0:
+            correct_search_result_list[i] = correct_search_result / len(response)
+        else:
+            correct_search_result_list[i] = 0
 
 
     

--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -153,7 +153,10 @@ def calculateScore(responses = [], tag = 'tao'):
         time_diff_list[i] = time_diff_score
         length_list[i] = len(response)
         correct_list[i] = correct_score
-        correct_search_result_list[i] = correct_search_result / len(response)
+        if len(response) > 0:
+            correct_search_result_list[i] = correct_search_result / len(response)
+        else:
+            correct_search_result_list[i] = 0
 
     
 


### PR DESCRIPTION
* Fix for failing to score if one miner returns empty list (which happens regularly).
* Nodes that haven't been queried will now score 0, instead of 1.
* Scores are persisted across runs.