### PR TITLE
Scoring fixes: tweet spot-checks, and reddit similarity_score/time_diff scores.

### DIFF
--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -138,16 +138,17 @@ def calculateScore(responses = [], tag = 'tao'):
                             if searched_item:
                                 if(searched_item[0]['text'] == sample_item['text'] and searched_item[0]['timestamp'] == sample_item['timestamp']):
                                     correct_score += 1
+                                else:
+                                    bt.logging.info(f"Tampered tweet! {sample_item}")
                             else: 
-                                correct_score += 0
+                                bt.logging.info(f"No result returned for {sample_item['url']}")
                         except Exception as e:
-                            bt.logging.error(f"Error while verifying tweet: {e}")
-                    correct_score /= len(sample_items) + 1
+                            bt.logging.error(f"❌ Error while verifying tweet: {e}")
+                    correct_score /= len(sample_items)
             # calculate scores
             for i_item, item in enumerate(response):
                 if tag.lower() in item['text'].lower():
                     correct_search_result += 1
-
                 # calculate similarity score
                 similarity_score += (id_counts[item['id']] - 1)
                 # calculate time difference score


### PR DESCRIPTION
Any tweet selected for spot-check verification was resulting in assigning a score of 0 to that miner.

And the similarity_score and time_diff score loops in the reddit scoring were indented in such a way that they were only being run for miners selected for spot-check. They should be run for all miner responses.

Also, there is some more logging around scoring added. I can remove that if you do not want more logging.