### PR TITLE
Responses without search term penalized heavily

### DIFF
--- a/neurons/score/reddit_score.py
+++ b/neurons/score/reddit_score.py
@@ -145,8 +145,11 @@ def calculateScore(responses = [], tag = 'tao'):
         try:
             # calculate scores
             for i_item, item in enumerate(response):
-                if tag.lower() in item['text'].lower():
+                if tag.lower() in item['title'].lower():
                     relevant_count += 1
+                elif tag.lower() in item['text'].lower():
+                    relevant_count += 1
+
                 # calculate similarity score
                 similarity_score += (id_counts[item['id']] - 1)
                 # calculate time difference score

--- a/neurons/score/reddit_score.py
+++ b/neurons/score/reddit_score.py
@@ -60,8 +60,7 @@ def calculateScore(responses = [], tag = 'tao'):
     correct_list = torch.ones(len(responses))
     total_length = 0
     max_length = 0
-    max_correct_search = 0
-    correct_search_result_list = torch.zeros(len(responses))
+    relevant_ratio = torch.zeros(len(responses))
 
     format_score = torch.zeros(len(responses))
     fake_score = torch.zeros(len(responses))
@@ -80,6 +79,7 @@ def calculateScore(responses = [], tag = 'tao'):
                 # Check that 'text' and 'timestamp' fields exist
                 post['text'] and post['timestamp']
                 if post['id'] in id_list:
+                    bt.logging.info(f"Duplicated id found: {post['id']} in response {i}")
                     fake_score[i] = 1
                 else:
                     id_list.append(post['id'])
@@ -87,7 +87,8 @@ def calculateScore(responses = [], tag = 'tao'):
                 post_id = post['id']
                 id_counts[post_id] = id_counts.get(post_id, 0) + 1
                 
-            except:
+            except Exception as e:
+                bt.logging.error(f"❌ Error while verifying post: {e}: {post}")
                 format_score[i] = 1
 
     # Choose random responses from each miner to compare, and gather their urls
@@ -116,7 +117,7 @@ def calculateScore(responses = [], tag = 'tao'):
     for i, response in enumerate(responses):
         # initialize variables
         similarity_score = 0
-        correct_search_result = 0
+        relevant_count = 0
         time_diff_score = 0
         total_length += len(response)
 
@@ -145,7 +146,7 @@ def calculateScore(responses = [], tag = 'tao'):
             # calculate scores
             for i_item, item in enumerate(response):
                 if tag.lower() in item['text'].lower():
-                    correct_search_result += 1
+                    relevant_count += 1
                 # calculate similarity score
                 similarity_score += (id_counts[item['id']] - 1)
                 # calculate time difference score
@@ -163,34 +164,33 @@ def calculateScore(responses = [], tag = 'tao'):
             max_time_diff = time_diff_score
         if max_correct_score < correct_score:
             max_correct_score = correct_score
-        if max_correct_search < correct_search_result:
-            max_correct_search = correct_search_result
+
 
         similarity_list[i] = similarity_score
         time_diff_list[i] = time_diff_score
         length_list[i] = len(response)
         correct_list[i] = correct_score
+
         if len(response) > 0:
-            correct_search_result_list[i] = correct_search_result / len(response)
+            relevant_ratio[i] = relevant_count / len(response)
         else:
-            correct_search_result_list[i] = 0
+            relevant_ratio[i] = 0
 
-
-    bt.logging.info(f"length_list: {length_list}")
-    bt.logging.info(f"correct_list: {correct_list}")
-    bt.logging.info(f"similarity_list: {similarity_list}")
 
     similarity_list = (similarity_list + 1) / (max_similar_count + 1)
     time_diff_list = (time_diff_list + 1) / (max_time_diff + 1)
     correct_list = (correct_list + 1) / (max_correct_score + 1)
-    length_list = (length_list + 1) / (max_length + 1)
+    length_normalized = (length_list + 1) / (max_length + 1)
 
-    bt.logging.info(f"time_diff contribution: {(1 - time_diff_list) * 0.2}")
-    bt.logging.info(f"length contribution: {length_list * 0.3}")
-    bt.logging.info(f"similarity contribution: {(1 - similarity_list) * 0.3}")
-    bt.logging.info(f"correct_search contribution: {correct_search_result_list * 0.2}")
-        
-    score_list = ((1 - similarity_list) * 0.3  + (1 - time_diff_list) * 0.2 + length_list * 0.3 + correct_search_result_list * 0.2)
+    time_diff_contribution = (1 - time_diff_list) * 0.2
+    length_contribution = length_normalized * 0.3
+    similarity_contribution = (1 - similarity_list) * 0.3
+    relevancy_contribution = relevant_ratio * 0.2
+
+    score_list = (similarity_contribution + time_diff_contribution + length_contribution + relevancy_contribution)
+
+    pre_filtered_score = score_list.clone()
+
     for i, correct_list_item in enumerate(correct_list):
         if correct_list_item < 1:
             score_list[i] = 0
@@ -198,15 +198,39 @@ def calculateScore(responses = [], tag = 'tao'):
             score_list[i] = 0
         if fake_score[i] == 1:
             score_list[i] = 0
+        if relevant_ratio[i] < 0.5:
+            score_list[i] = 0
+
     for i, response in enumerate(responses):
         if response == [] or response == None:
             score_list[i] = 0
+
+    filtered_scores = score_list.clone()
+
     # normalize score list
+
     if torch.sum(score_list) == 0:
         pass
     else:
-        score_list = score_list / torch.sum(score_list)
-    return score_list
+        normalized_scores = score_list / torch.sum(score_list)
+
+    scoring_metrics = {
+        "correct": correct_list,
+        "similarity": similarity_list,
+        "time_diff": time_diff_list,
+        "time_contrib": time_diff_contribution,
+        "length": length_list,
+        "length_contrib": length_contribution,
+        "similarity_contrib": similarity_contribution,
+        "relevancy_contrib": relevancy_contribution,
+        "format": format_score,
+        "fake": fake_score,
+        "pre_filtered_score": pre_filtered_score,
+        "filtered_scores": filtered_scores,
+        "normalized_scores": normalized_scores,
+    }
+
+    return scoring_metrics
         
 
 

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
Any miner responses with > 50% of responses lacking the search term will be scored as 0.

Also adds a scoring detail debug saving mechanism that is disabled by default. To enable pass `--save_scoring yes` on the validator command line.