### PR TITLE
Average age scoring and storage fixes

### DIFF
--- a/neurons/score/reddit_score.py
+++ b/neurons/score/reddit_score.py
@@ -44,14 +44,12 @@ def calculateScore(responses = [], tag = 'tao'):
     # Initialize variables
     # Initialize score list. The length of score list is the same as the length of responses.
     score_list = torch.zeros(len(responses))
-    # Initialize time difference list. The length of time difference list is the same as the length of responses.
-    time_diff_list = torch.zeros(len(responses))
+    # Initialize average age list. The length of average age list is the same as the length of responses.
+    average_age_list = torch.zeros(len(responses))
 
     correct_score = 0
     max_correct_score = 0
-    max_time_diff = 0
-    # Initialize accuracy list. The length of accuracy list is the same as the length of responses.
-    accuracy_list = torch.zeros(len(responses))
+    max_average_age = 0
     # Initialize similarity list. The length of similarity list is the same as the length of responses.
     similarity_list = torch.zeros(len(responses))
     max_similar_count = 0
@@ -118,7 +116,7 @@ def calculateScore(responses = [], tag = 'tao'):
         # initialize variables
         similarity_score = 0
         relevant_count = 0
-        time_diff_score = 0
+        age_sum = 0
         total_length += len(response)
 
         # update max_length
@@ -163,41 +161,43 @@ def calculateScore(responses = [], tag = 'tao'):
                 date_string = date_temp.strftime('%Y-%m-%d %H:%M:%S+00:00')
                 date_object = datetime.datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S+00:00')
                 time_diff = datetime.datetime.now() - date_object
-                time_diff_score += time_diff.seconds
+                age_sum += time_diff.seconds
         except Exception as e:
             bt.logging.info(f"Bad format: {e}")
             format_score[i] = 1
 
+
         if max_similar_count < similarity_score:
             max_similar_count = similarity_score
-        if max_time_diff < time_diff_score:
-            max_time_diff = time_diff_score
         if max_correct_score < correct_score:
             max_correct_score = correct_score
 
-
         similarity_list[i] = similarity_score
-        time_diff_list[i] = time_diff_score
         length_list[i] = len(response)
         correct_list[i] = correct_score
 
         if len(response) > 0:
             relevant_ratio[i] = relevant_count / len(response)
+            average_age = age_sum / len(response)
         else:
             relevant_ratio[i] = 0
+            average_age = 0 # 0 is the "best" age, but miners with no posts will still score 0
 
+        if max_average_age < average_age:
+            max_average_age = average_age
 
+        average_age_list[i] = average_age
+    
     similarity_list = (similarity_list + 1) / (max_similar_count + 1)
-    time_diff_list = (time_diff_list + 1) / (max_time_diff + 1)
     correct_list = (correct_list + 1) / (max_correct_score + 1)
     length_normalized = (length_list + 1) / (max_length + 1)
 
-    time_diff_contribution = (1 - time_diff_list) * 0.2
+    age_contribution = (1 - (average_age_list + 1) / (max_average_age + 1)) * 0.2
     length_contribution = length_normalized * 0.3
     similarity_contribution = (1 - similarity_list) * 0.3
     relevancy_contribution = relevant_ratio * 0.2
 
-    score_list = (similarity_contribution + time_diff_contribution + length_contribution + relevancy_contribution)
+    score_list = (similarity_contribution + age_contribution + length_contribution + relevancy_contribution)
 
     pre_filtered_score = score_list.clone()
 
@@ -227,8 +227,8 @@ def calculateScore(responses = [], tag = 'tao'):
     scoring_metrics = {
         "correct": correct_list,
         "similarity": similarity_list,
-        "time_diff": time_diff_list,
-        "time_contrib": time_diff_contribution,
+        "average_age": average_age_list,
+        "time_contrib": age_contribution,
         "length": length_list,
         "length_contrib": length_contribution,
         "similarity_contrib": similarity_contribution,

--- a/neurons/storage/store.py
+++ b/neurons/storage/store.py
@@ -39,7 +39,7 @@ def twitter_store(data = [], search_keys = []):
     filename = 'twitter_' + generate_random_string() + '.csv'
 
     csv_buffer = StringIO()
-    fieldnames = ['id', 'url', 'text', 'likes', 'images', 'timestamp']
+    fieldnames = ['id', 'url', 'text', 'likes', 'images', 'timestamp', 'username', 'hashtags']
 
     writer = csv.DictWriter(csv_buffer, fieldnames=fieldnames)
 
@@ -56,6 +56,7 @@ def twitter_store(data = [], search_keys = []):
                         writer.writerow(item)
                         total_count += 1
     if total_count > 0:
+        bt.logging.info(f"Storing results as twitterscrapingbucket/twitter/{filename}")
         s3.Bucket('twitterscrapingbucket').put_object(Key='twitter/' + filename, Body=csv_buffer.getvalue())
 
         csv_buffer.close()
@@ -69,7 +70,7 @@ def reddit_store(data = [], search_keys = []):
     filename = 'reddit_' + generate_random_string() + '.csv'
 
     csv_buffer = StringIO()
-    fieldnames = ['id', 'url', 'text', 'likes', 'dataType', 'timestamp']
+    fieldnames = ['id', 'url', 'text', 'likes', 'dataType', 'timestamp', 'username', 'parent', 'community', 'title', 'num_comments', 'user_id']
 
     writer = csv.DictWriter(csv_buffer, fieldnames=fieldnames)
     total_count = 0
@@ -87,6 +88,7 @@ def reddit_store(data = [], search_keys = []):
                         total_count += 1
   
     if total_count > 0:
+        bt.logging.info(f"Storing results as redditscrapingbucket/reddit/{filename}")
         s3.Bucket('redditscrapingbucket').put_object(Key='reddit/' + filename, Body=csv_buffer.getvalue())
 
         csv_buffer.close()

--- a/neurons/storage/store.py
+++ b/neurons/storage/store.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 import os
 import requests
 import json
+import bittensor as bt
 
 load_dotenv()
 wasabi_endpoint_url = os.getenv("WASABI_ENDPOINT_URL")
@@ -22,12 +23,16 @@ s3 = boto3.resource('s3',
 def generate_random_string(length=10):
     return ''.join(random.choice(string.ascii_lowercase) for i in range(length))
 
+def scoring_bucket():
+    return s3.Bucket('scoring')
 
 def store_scoring_metrics(metrics: dict, type: str):
     block = metrics['block']
     filename = f"{block:09}_{generate_random_string()}.json"
     data = json.dumps(metrics)
-    s3.Bucket('scoring').put_object(Key=f"{type}/{filename}", Body=data)
+    key = f"{type}/{filename}"
+    s3.Bucket('scoring').put_object(Key=key, Body=data)
+    bt.logging.info(f"Stored scoring metrics to {key}")
 
 def twitter_store(data = [], search_keys = []):
     id_list = []

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
Previous scoring would penalize miners for returning more data.  A miner returning 1 tweet that was a day old would get a higher score (time-diff = 24 hours) than 10 tweets that were 3 hours old (time-diff = 30 hours).  This changes the scoring math from adding up the total age of all items, to using the average age.

This also fixes an issue where additional fields in tweets and reddit content were preventing storage to wasabi.