### PR TITLE
Reduce similarity penalty and increase weight of recency

### DIFF
--- a/neurons/score/reddit_score.py
+++ b/neurons/score/reddit_score.py
@@ -20,7 +20,7 @@ DEALINGS IN THE SOFTWARE.
 # importing necessary libraries and modules
 
 import torch
-import datetime
+from datetime import datetime
 import bittensor as bt
 from neurons.queries import get_query, QueryType, QueryProvider
 import random
@@ -159,8 +159,8 @@ def calculateScore(responses = [], tag = 'tao'):
                 # calculate time difference score
                 date_temp = parse(item['timestamp'])
                 date_string = date_temp.strftime('%Y-%m-%d %H:%M:%S+00:00')
-                date_object = datetime.datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S+00:00')
-                time_diff = datetime.datetime.now() - date_object
+                date_object = datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S+00:00')
+                time_diff = datetime.now() - date_object
                 age_sum += time_diff.seconds
         except Exception as e:
             bt.logging.info(f"Bad format: {e}")
@@ -191,10 +191,10 @@ def calculateScore(responses = [], tag = 'tao'):
     similarity_list = (similarity_list + 1) / (max_similar_count + 1)
     correct_list = (correct_list + 1) / (max_correct_score + 1)
     length_normalized = (length_list + 1) / (max_length + 1)
-
-    age_contribution = (1 - (average_age_list + 1) / (max_average_age + 1)) * 0.2
+    
+    age_contribution = (1 - (average_age_list + 1) / (max_average_age + 1)) * 0.4
     length_contribution = length_normalized * 0.3
-    similarity_contribution = (1 - similarity_list) * 0.3
+    similarity_contribution = (1 - similarity_list) * 0.1
     relevancy_contribution = relevant_ratio * 0.2
 
     score_list = (similarity_contribution + age_contribution + length_contribution + relevancy_contribution)

--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -20,7 +20,7 @@ DEALINGS IN THE SOFTWARE.
 # importing necessary libraries and modules
 
 import torch
-import datetime
+from datetime import datetime
 import random
 import bittensor as bt
 from urllib.parse import urlparse
@@ -201,8 +201,8 @@ def calculateScore(responses = [], tag = 'tao'):
             # calculate similarity score
             similarity_score += (id_counts[item['id']] - 1)
             # calculate time difference score
-            date_object = datetime.datetime.strptime(item['timestamp'], '%Y-%m-%d %H:%M:%S+00:00')
-            age = datetime.datetime.now() - date_object
+            date_object = datetime.strptime(item['timestamp'], '%Y-%m-%d %H:%M:%S+00:00')
+            age = datetime.now() - date_object
             age_sum += age.seconds
 
         if max_similar_count < similarity_score:
@@ -231,9 +231,9 @@ def calculateScore(responses = [], tag = 'tao'):
     correct_list = (correct_list + 1) / (max_correct_score + 1)
     length_normalized = (length_list + 1) / (max_length + 1)
 
-    age_contribution = (1 - (average_age_list + 1) / (max_average_age + 1)) * 0.2
+    age_contribution = (1 - (average_age_list + 1) / (max_average_age + 1)) * 0.4
     length_contribution = length_normalized * 0.3
-    similarity_contribution = (1 - similarity_list) * 0.3
+    similarity_contribution = (1 - similarity_list) * 0.1
     relevancy_contribution = relevant_ratio * 0.2
 
     score_list = (similarity_contribution + age_contribution + length_contribution + relevancy_contribution)

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.5"
+__version__ = "2.2.6"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
Miners have been filtering out very recent (like in the last hour) tweets and posts to avoid the similarity penalty, which is very costly in terms of scoring.  This reduces the weight of the similarity penalty from 0.3 to 0.1 and increases the weight of the recency score from 0.2 to 0.4. 