### PR TITLE
Allow X username to be part of relevancy score

### DIFF
--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -196,7 +196,7 @@ def calculateScore(responses = [], tag = 'tao'):
 
         # calculate scores
         for i_item, item in enumerate(response):
-            if tag.lower() in item['text'].lower():
+            if tag.lower() in item['text'].lower() or tag.lower() in item.get('username', ''):
                 relevant_count += 1
             # calculate similarity score
             similarity_score += (id_counts[item['id']] - 1)

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.6"
+__version__ = "2.2.7"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
I've seen validators querying with labels that match specific X handles, which seems like a reasonable use case. This PR allows miners to submit responses where the X user's handle contains the query string. Case-insensitive, like the text body match.