### PR TITLE
Future time fix

### DIFF
--- a/neurons/apify/tweeter/microworlds_twitter_scraper.py
+++ b/neurons/apify/tweeter/microworlds_twitter_scraper.py
@@ -57,6 +57,7 @@ class MicroworldsTwitterScraper:
         run_input = {
             "maxRequestRetries": 3,
             "searchMode": "live",
+            "scrapeTweetReplies": True,
             "searchTerms": search_queries,
             "maxTweets": limit_number
         }
@@ -89,7 +90,7 @@ class MicroworldsTwitterScraper:
         return {
             'id': item['id_str'], 
             'url': item['url'], 
-            'text': item['full_text'], 
+            'text': item.get('truncated_full_text') or item['full_text'], 
             'likes': item['favorite_count'], 
             'images': images, 
             'username': item['user']['screen_name'],
@@ -122,7 +123,7 @@ if __name__ == '__main__':
     print(f"Fetched {len(urls)} urls: {urls}")
 
     data_set = query.searchByUrl(urls=urls)
-    
+
     verified_urls = [tweet['url'] for tweet in data_set]
 
     print(f"Verification returned {len(verified_urls)} tweets")
@@ -139,6 +140,8 @@ if __name__ == '__main__':
         unverified = set(urls) - set(verified_urls) - set(verified_urls2)
 
         print(f"Num unverified: {len(unverified)}: {unverified}")
+    else:
+        print("All verified!")
 
     # Output the tweet data
     #for item in data_set:

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.9"
+__version__ = "2.2.10"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
* Miners could set a single tweet in their response to a very far future date, and because only one tweet in the response is getting spot checked, this could often pass undetected, but still affect age scoring greatly.
* Adds getting full text (`truncated_full_text`) from microworlds twitter scraper.