### PR TITLE
Fix issue when running on python 3.11

### DIFF
--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -158,7 +158,7 @@ def calculateScore(responses = [], tag = 'tao'):
             tries = 0
             remaining_urls = set(spot_check_urls)
             while tries < 2 and len(remaining_urls) > 0:
-                urls = random.sample(remaining_urls, k=min(20, len(remaining_urls)))
+                urls = random.sample(sorted(remaining_urls), k=min(20, len(remaining_urls)))
                 bt.logging.info(f"Fetching {len(urls)} tweets out of {len(remaining_urls)} remaining to validate.")
                 max_tweets_per_url = 1 if tries == 0 else 10 
                 batch_tweets = twitter_query.searchByUrl(urls, max_tweets_per_url)

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.14"
+__version__ = "2.2.15"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
The twitter scoring fails due to an issue with random.sample being passed a set, when run on python 3.11 or higher.  Any validators wanting to run on that version of python or higher will need this fix.