### PR TITLE
Apidojo update

### DIFF
--- a/neurons/apify/tweeter/apidojo_tweet_scraper.py
+++ b/neurons/apify/tweeter/apidojo_tweet_scraper.py
@@ -1,0 +1,134 @@
+import logging
+from neurons.apify.actors import run_actor, run_actor_async, ActorConfig
+from datetime import datetime, timezone
+import asyncio
+
+# Setting up logger for debugging and information purposes
+logger = logging.getLogger(__name__)
+
+class ApiDojoTweetScraper:
+    """
+    A class designed to query tweets based using the apidojo/tweet-scraper actor on the Apify platform.
+
+    Attributes:
+        actor_config (ActorConfig): Configuration settings specific to the Apify actor.
+    """
+
+    def __init__(self):
+        """
+        Initialize the ApiDojoTweetScraper.
+        """
+        self.actor_config = ActorConfig("61RPP7dywgiy0JPD0")
+        self.actor_config.timeout_secs = 120
+
+
+    async def searchBatch(self, urls: list):
+        run_input = {
+            "maxItems": len(urls),
+            "maxTweetsPerQuery": 1,
+            "onlyImage": False,
+            "onlyQuote": False,
+            "onlyTwitterBlue": False,
+            "onlyVerifiedUsers": False,
+            "onlyVideo": False,
+            "startUrls": urls
+        }
+        results = await run_actor_async(self.actor_config, run_input)
+        return results
+
+    def searchByUrl(self, urls: list, max_tweets_per_url: int = 1):
+        """
+        Search for tweets by url.
+        """
+
+        results = asyncio.run(self.searchBatch(urls))
+        return self.map(results)
+    
+    def format_date(self, date: datetime):
+        date = date.replace(tzinfo=timezone.utc)
+        return date.isoformat(sep=' ', timespec='seconds')
+
+    def map_item(self, item) -> dict:
+        hashtags = ["#" + x["text"] for x in item.get("entities", {}).get('hashtags', [])]
+
+        images = []
+
+        extended_entities = item.get("extendedEntities")
+        if extended_entities:
+            media_urls = {m["media_key"]: m["media_url_https"] for m in extended_entities["media"] if m.get("media_url_https")}
+
+        for media in item.get("entities", {}).get('media', []):
+            media_key = media.get("media_key")
+            if media_key:
+                images.append(media_urls[media_key])
+
+
+        date_format = "%a %b %d %H:%M:%S %z %Y"
+        parsed_date = datetime.strptime(item["createdAt"], date_format)
+
+        return {
+            'id': item['id'], 
+            'url': item['twitterUrl'], 
+            'text': item.get('text'), 
+            'likes': item['likeCount'], 
+            'images': images, 
+            'username': item['author']['userName'],
+            'hashtags': hashtags,
+            'timestamp': self.format_date(parsed_date)
+        } 
+
+    def map(self, input: list) -> list:
+        """
+        Map the input data to the expected sn3 format.
+
+        Args:
+            input (list): The data to potentially map or transform.
+
+        Returns:
+            list: The mapped or transformed data.
+        """
+        filtered_input = [self.map_item(item) for item in input]
+        return filtered_input
+
+
+if __name__ == '__main__':
+    # Initialize the tweet query mechanism
+    query = ApiDojoTweetScraper()
+
+    urls = [
+        "https://twitter.com/SharpeSignals/status/1763528065374884229",
+        "https://twitter.com/dievardump/status/1763569657779233026",
+        "https://twitter.com/punk9059/status/1763569822007165354",
+        "https://twitter.com/whomst69/status/1763569997442355504",
+        "https://twitter.com/DenjinK/status/1763457333643153485",
+        "https://twitter.com/r1ddo/status/1763537662403625196"
+    ]
+
+    data_set = query.searchByUrl(urls=urls)
+
+    verified_urls = [tweet['url'] for tweet in data_set]
+
+    print(f"Verification returned {len(verified_urls)} tweets")
+
+    if data_set:
+        print(f"First tweet: {data_set[0]}")
+
+    print(f"There are {len(set(verified_urls))} unique urls")
+
+    unverified = set(urls) - set(verified_urls)
+
+    if len(unverified) > 0:
+        print(f"Num unverified: {len(unverified)}: {unverified}, trying again")
+        data_set2 = query.searchByUrl(urls=unverified)
+
+        verified_urls2 = [tweet['url'] for tweet in data_set2]
+
+        unverified = set(urls) - set(verified_urls) - set(verified_urls2)
+
+        print(f"Num unverified: {len(unverified)}: {unverified}")
+    else:
+        print("All verified!")
+
+    # Output the tweet data
+    #for item in data_set:
+    #    print(item)

--- a/neurons/queries.py
+++ b/neurons/queries.py
@@ -5,6 +5,7 @@ from neurons.apify.tweeter.tweet_flash_query import TweetFlashQuery
 from neurons.apify.tweeter.tweet_scraper_query import TweetScraperQuery
 from neurons.apify.tweeter.web_harvester_twitter_scraper_query import WebHarvesterTwitterScraperQuery
 from neurons.apify.tweeter.microworlds_twitter_scraper import MicroworldsTwitterScraper
+from neurons.apify.tweeter.apidojo_tweet_scraper import ApiDojoTweetScraper
 from neurons.apify.reddit.reddit_scraper_lite import RedditScraperLite
 from neurons.apify.reddit.reddit_scraper import RedditScraper
 from neurons.apify.reddit.epctex_reddit_scraper import EpctexRedditScraper
@@ -33,6 +34,7 @@ class QueryProvider(Enum):
     EPCTEX_REDDIT_SCRAPER = "epctex_reddit_scraper"
     PERCIPIO_REDDIT_LOOKUP = "percipio_reddit_lookup"
     MICROWORLDS_TWITTER_SCRAPER = "microworlds_twitter_scraper"
+    APIDOJO_TWEET_SCRAPER = "apidojo_tweet_scraper"
 
 
 # Mapping between query types and their respective classes
@@ -41,6 +43,7 @@ QUERY_MAP = {
     (QueryType.TWITTER, QueryProvider.TWEET_FLASH): TweetFlashQuery,
     (QueryType.TWITTER, QueryProvider.WEB_HARVESTER_TWITTER_SCRAPER): WebHarvesterTwitterScraperQuery,    
     (QueryType.TWITTER, QueryProvider.MICROWORLDS_TWITTER_SCRAPER): MicroworldsTwitterScraper,    
+    (QueryType.TWITTER, QueryProvider.APIDOJO_TWEET_SCRAPER): ApiDojoTweetScraper,    
     (QueryType.REDDIT, QueryProvider.REDDIT_SCRAPER_LITE): RedditScraperLite,
     (QueryType.REDDIT, QueryProvider.REDDIT_SCRAPER): RedditScraper,
     (QueryType.REDDIT, QueryProvider.EPCTEX_REDDIT_SCRAPER): EpctexRedditScraper,

--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -158,7 +158,7 @@ def calculateScore(responses = [], tag = 'tao'):
             tries = 0
             remaining_urls = set(spot_check_urls)
             while tries < 2 and len(remaining_urls) > 0:
-                urls = random.sample(remaining_urls, k=min(20, len(remaining_urls)))
+                urls = random.sample(sorted(remaining_urls), k=min(20, len(remaining_urls)))
                 bt.logging.info(f"Fetching {len(urls)} tweets out of {len(remaining_urls)} remaining to validate.")
                 max_tweets_per_url = 1 if tries == 0 else 10 
                 batch_tweets = twitter_query.searchByUrl(urls, max_tweets_per_url)

--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -30,29 +30,8 @@ import re
 import html
 from neurons.queries import get_query, QueryType, QueryProvider
 
-twitter_query = get_query(QueryType.TWITTER, QueryProvider.MICROWORLDS_TWITTER_SCRAPER)
+twitter_query = get_query(QueryType.TWITTER, QueryProvider.APIDOJO_TWEET_SCRAPER)
 
-from itertools import islice
-
-def chunk(it, size):
-    it = iter(it)
-    return iter(lambda: tuple(islice(it, size)), ())
-
-
-# Removes links, leading mentions, whitespace, and convert html entities
-def text_for_comparison(text):
-    # url shorteners can cause problems with tweet verification, so remove urls from the text comparison.
-    text = re.sub(r'(https?://)?\S+\.\S+\/?(\S+)?', '', text)
-    # Some scrapers put the mentions at the front of the text, remove them.
-    text = re.sub(r'^(@\w+\s*)+', '', text)
-    # And some trim trailing whitespace at the end of newlines, so ignore whitespace.
-    text = re.sub(r'\s+', '', text)
-    # And some have special characters escaped as html entities
-    text = html.unescape(text)
-    # The validator apify actor uses the tweet.text field and not the note_tweet field (> 280) charts, so only
-    # use the first 255 chars for comparison.
-    text = text[:255]
-    return text
 
 def parse_date(dateStr: str):
     return datetime.strptime(dateStr, '%Y-%m-%d %H:%M:%S+00:00')
@@ -160,8 +139,7 @@ def calculateScore(responses = [], tag = 'tao'):
             while tries < 2 and len(remaining_urls) > 0:
                 urls = random.sample(sorted(remaining_urls), k=min(20, len(remaining_urls)))
                 bt.logging.info(f"Fetching {len(urls)} tweets out of {len(remaining_urls)} remaining to validate.")
-                max_tweets_per_url = 1 if tries == 0 else 10 
-                batch_tweets = twitter_query.searchByUrl(urls, max_tweets_per_url)
+                batch_tweets = twitter_query.searchByUrl(urls)
                 batch_urls = set([tweet['url'] for tweet in batch_tweets])
                 bt.logging.info(f"Fetched {len(batch_urls)}.")
                 remaining_urls = remaining_urls - set(batch_urls)
@@ -192,8 +170,8 @@ def calculateScore(responses = [], tag = 'tao'):
             searched_item = next((tweet for tweet in spot_check_tweets if tweet['id'] == sample_item['id']), None)
             if searched_item:
                 # Normalize text to account for variations in scraped data.
-                miner_text = text_for_comparison(sample_item['text'])
-                verify_text = text_for_comparison(searched_item['text'])
+                miner_text = sample_item['text']
+                verify_text = searched_item['text']
 
                 if(verify_text == miner_text and searched_item['timestamp'] == sample_item['timestamp']):
                     correct_score = 1

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -230,7 +230,7 @@ def main( config ):
             # Broadcast a GET_DATA query to filtered miners on the network.
 
             # * every 10 minutes, query the miners for twitter data
-            if step % 4 == 2:
+            if step % 4 == 0:
                 search_key = random_line()
                 bt.logging.info(f"\033[92m 𝕏 ⏩ Sending tweeter query ({search_key}). \033[0m")
                 responses = dendrite.query(
@@ -258,7 +258,7 @@ def main( config ):
                         scoring_metrics['block'] = subtensor.block
 
                         if config.save_scoring:
-                            dir = f'twitter_block_{subtensor.block}'
+                            dir = f'/opt/data/sn3/twitter_block_{subtensor.block}'
                             os.mkdir(dir)
                             with open(f'{dir}/scoring.json', 'w') as output:
                                 json.dump(scoring_metrics, output)
@@ -317,7 +317,7 @@ def main( config ):
                     else: bt.logging.error('Failed to set weights.')
 
             # Periodically update the weights on the Bittensor blockchain.
-            if step % 4 == 0:
+            if step % 4 == 2:
                 bt.logging.info(f"\033[92m ᕕ ⏩ Sending reddit query. \033[0m")
                 search_key = random_line()
                 responses = dendrite.query(
@@ -345,7 +345,7 @@ def main( config ):
                         scoring_metrics['block'] = subtensor.block
 
                         if config.save_scoring:
-                            dir = f'reddit_block_{subtensor.block}'
+                            dir = f'/opt/data/sn3/reddit_block_{subtensor.block}'
                             os.mkdir(dir)
                             with open(f'{dir}/scoring.json', 'w') as output:
                                 json.dump(scoring_metrics, output)

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.14"
+__version__ = "2.2.15"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.2.15"
+__version__ = "2.3.0"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
This updates the validator to use the apidojo/tweet-scraper Apify Actor, which is more reliable, faster, and cheaper than the current microworlds actor.

For miners, this update is important. The `text` field of tweets was previously compared in a fuzzy way, where including leading reply-to handles was optional, url shortening style could vary, some whitespace changes were ignored, and html-escaping was optional for some characters.  After this update is merged, miners will need to make sure that the `text` field of tweets they submit conform to the following rules:

* Leading reply-to handles are included
* Urls are included in the text, and shortened via their t.co form.
* White space matches properly.
* Ampersand, <, and > are html escaped.

These rules match how the twitter api, the microworld scraper, and the apidojo scraper return results, so as long as you are using one of those sources, you should be ok. If not, you will need to make sure your source conforms to the above rules.
