### PR TITLE
Handle invalid tweet json from apidojo actor

### DIFF
--- a/scraping/__init__.py
+++ b/scraping/__init__.py
@@ -19,7 +19,7 @@ DEALINGS IN THE SOFTWARE.
 
 # Define the version of the scraping module.
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
Sometimes the apidojo actor returns json like this. Maybe for a deleted tweet?:
```
{
    "url": "https://x.com/undefined/status/undefined",
    "twitterUrl": "https://twitter.com/undefined/status/undefined",
    "isRetweet": false,
    "isQuote": false
  }
```

This change updates the validator to handle this error with less impact; previously it was causing validations for all tweets in that batch to fail; after this change, it will just fail the validation for the individual tweet.