### PR TITLE
Twitter username should be compared lowercase

### DIFF
--- a/neurons/score/twitter_score.py
+++ b/neurons/score/twitter_score.py
@@ -194,7 +194,7 @@ def calculateScore(responses = [], tag = 'tao'):
 
         # calculate scores
         for item in response:
-            if tag.lower() in item['text'].lower() or tag.lower() in item.get('username', ''):
+            if tag.lower() in item['text'].lower() or tag.lower() in item.get('username', '').lower():
                 relevant_count += 1
             # calculate similarity score
             similarity_score += (id_counts[item['id']] - 1)


### PR DESCRIPTION
It's a typo in the original code. The lowercase username should be checked against the lowercase tag to ignore casing. Should be merged before #95 since it doesn't bump the version.